### PR TITLE
FrameNet license

### DIFF
--- a/packages/corpora/framenet_v17.xml
+++ b/packages/corpora/framenet_v17.xml
@@ -1,6 +1,6 @@
 <package id="framenet_v17" name="FrameNet 1.7"
          author="Collin F. Baker"
-         license="May be used for non-commercial purposes."
+         license="Creative Commons Attribution 3.0 Unported License"
          webpage="http://framenet.icsi.berkeley.edu"
          unzip="1"
          />


### PR DESCRIPTION
Changing license for FrameNet 1.7.

FrameNet has had a CC-BY license for some time now, allowing commercial use. See
https://framenet.icsi.berkeley.edu/fndrupal/framenet_request_data
