### PR TITLE
Removing references to hmm_treebank_pos_tagger

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -267,7 +267,6 @@
       <item ref="words" />
       <item ref="ycoe" />
       <item ref="rslp" />
-      <item ref="hmm_treebank_pos_tagger" />
       <item ref="maxent_treebank_pos_tagger" />
       <item ref="universal_tagset" />
       <item ref="maxent_ne_chunker" />
@@ -374,7 +373,6 @@
       <item ref="words" />
       <item ref="ycoe" />
       <item ref="rslp" />
-      <item ref="hmm_treebank_pos_tagger" />
       <item ref="maxent_treebank_pos_tagger" />
       <item ref="universal_tagset" />
       <item ref="maxent_ne_chunker" />


### PR DESCRIPTION
Haven't created a pull request before
I forked so I could make the index work for myself, (avoiding error in https://stackoverflow.com/questions/47954097/nltk-error-on-nltk-all-collection-info-packages-typeerror-nonetype-object-i )
I made this pull request because I think this change is appropriate for the main branch...

I would also recommend changing `downloader.py` in NLTK ; it should handle "orphan references" in a different way, without "deleting while iterating"