### PR TITLE
Add Russian language for PunktSentenceTokenizer()

### DIFF
--- a/packages/tokenizers/punkt.xml
+++ b/packages/tokenizers/punkt.xml
@@ -1,6 +1,6 @@
 <package id='punkt' 
          name='Punkt Tokenizer Models'
          author='Jan Strunk'
-         languages="Czech, Danish, Dutch, English, Estonian, Finnish, French, German, Greek, Italian, Norwegian, Polish, Portuguese, Slovene, Spanish, Swedish, Turkish"
+         languages="Czech, Danish, Dutch, English, Estonian, Finnish, French, German, Greek, Italian, Norwegian, Polish, Portuguese, Russian, Slovene, Spanish, Swedish, Turkish"
          unzip="1"
          />


### PR DESCRIPTION
This commit adds Russian language support in `PunktSentenceTokenizer()`.
Data was taken from 3 sources:
– Articles from Russian Wikipedia (about 1 million sentences);
– Common Russian abbreviations from Russian orthographic dictionary, edited by V. V. Lopatin;
– Generated names initials.

After some research it was found that the single `params.abbrev_types` performs better than  together with `params.collocations` and `params.ortho_content`, so the latter were removed from the trained tokenizer.