### PR TITLE
PunktParameters stored as tab files

### DIFF
--- a/packages/tokenizers/punkt_tab.xml
+++ b/packages/tokenizers/punkt_tab.xml
@@ -1,0 +1,6 @@
+<package id='punkt_tab' 
+         name='Punkt Tokenizer Models'
+         author='Jan Strunk'
+         languages="Czech, Danish, Dutch, English, Estonian, Finnish, French, German, Greek, Italian, Malayalam, Norwegian, Polish, Portuguese, Russian, Slovene, Spanish, Swedish, Turkish"
+         unzip="1"
+         />


### PR DESCRIPTION
This package replaces the pickled Punkt models by PunktParameters stored in tab files. 

It seems that nltk.data loads Yaml and Json in a safe way, but 
the Tab format  may be preferable, as it is more concise, clearer to read, and probably even safer.
