### PR TITLE
maxent_ne chunkers data stored as tab-files

### DIFF
--- a/packages/chunkers/maxent_ne_chunker_tab.xml
+++ b/packages/chunkers/maxent_ne_chunker_tab.xml
@@ -1,0 +1,5 @@
+<package id='maxent_ne_chunker_tab'
+         name='ACE Named Entity Chunker (Maximum entropy)'
+         languages="English"
+         unzip="1"
+         />


### PR DESCRIPTION
This package replaces the unsafe pickled _maxent_ne chunkers_ data by safe tab-files.
