### PR TITLE
Clarify licensing, add CONTRIBUTING.md, and update README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,10 @@ git checkout -b add-my-dataset
 - Place your dataset in the appropriate directory (`corpora/`, `models/`, `tokenizers/`, etc.). If you are unsure, check the existing structure or open an issue for clarification.
 - If your dataset has a license, include the license file in the same directory. If the license is unknown or separate from the repository, please add a note in a `README` or `LICENSE` file within the dataset’s folder, and document this in your pull request.
 
+**Whenever you add a new data package, you must update [`DATASET-LICENSES.md`](DATASET-LICENSES.md) with the license information for your package.**
+
+You only need to update [`LICENSE-OVERVIEW.md`](LICENSE-OVERVIEW.md) if you are making changes to the repository’s overall licensing structure or guidance.
+
 ### 4. Update Index Files
 
 - If required, update any index or metadata files so that the new dataset is discoverable by NLTK’s downloader. Follow the format of the existing files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing to nltk_data
+
+Thank you for your interest in contributing to [`nltk_data`](https://github.com/nltk/nltk_data)! This guide will help you add new data packages (corpora, taggers, models, etc.) and contribute improvements to existing ones.
+
+## Adding a New Data Package
+
+The `nltk_data` repository contains datasets and resources that can be downloaded by `nltk.downloader`. To add a new dataset or resource, please follow these steps:
+
+### 1. Fork and Clone the Repository
+
+First, fork the [`nltk_data`](https://github.com/nltk/nltk_data) repository to your own GitHub account. For help with forking, see the [GitHub documentation on forking a repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
+
+Then, clone your fork locally:
+
+```bash
+git clone https://github.com/<your-github-username>/nltk_data.git
+cd nltk_data
+```
+
+### 2. Create a New Branch
+
+Create a branch for your dataset:
+
+```bash
+git checkout -b add-my-dataset
+```
+
+### 3. Add Your Data Package
+
+- Place your dataset in the appropriate directory (`corpora/`, `models/`, `tokenizers/`, etc.). If you are unsure, check the existing structure or open an issue for clarification.
+- If your dataset has a license, include the license file in the same directory. If the license is unknown or separate from the repository, please add a note in a `README` or `LICENSE` file within the dataset’s folder, and document this in your pull request.
+
+### 4. Update Index Files
+
+- If required, update any index or metadata files so that the new dataset is discoverable by NLTK’s downloader. Follow the format of the existing files.
+- Provide a short README or metadata file describing the package, its origin, and its license.
+
+### 5. Commit and Push Your Changes
+
+```bash
+git add <your new files>
+git commit -m "Add <name> dataset to nltk_data"
+git push origin add-my-dataset
+```
+
+### 6. Create a Pull Request
+
+Open a pull request from your branch to the `master` branch of `nltk/nltk_data`. For help, see the [GitHub documentation on creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
+
+In your pull request, please include:
+- A description of the dataset and its purpose.
+- Any relevant licensing information or restrictions.
+- Instructions for any special installation or usage requirements.
+
+### 7. Respond to Feedback
+
+- Be responsive to comments and requested changes.
+- If your dataset cannot be accepted (e.g., due to licensing issues), we will let you know in the pull request.
+
+## General Guidelines
+
+- **Licensing**: Please ensure you have the right to redistribute any data you submit, and document the license clearly. If the license is unknown, state this explicitly in your pull request.
+- **No Large Files**: If your package is extremely large, consider hosting it elsewhere and providing an index/manifest, or open an issue to discuss options.
+- **No Executable Files**: Only data, not code, should be included unless a script is essential for using the dataset.
+
+## Additional Resources
+
+- [GitHub Docs: Fork a repo](https://docs.github.com/en/get-started/quickstart/fork-a-repo)
+- [GitHub Docs: Branches](https://docs.github.com/en/get-started/quickstart/github-glossary#branch)
+- [GitHub Docs: Pull Requests](https://docs.github.com/en/pull-requests)
+
+If you have questions or need help, please open an issue or join the [nltk-dev mailing list](https://groups.google.com/forum/#!forum/nltk-dev).
+
+---
+
+Thank you for helping improve NLTK’s data resources!

--- a/DATASET-LICENSES.md
+++ b/DATASET-LICENSES.md
@@ -1,0 +1,229 @@
+# Dataset Licenses
+
+This document provides a grouped summary of licenses for data packages present in the [`nltk_data`](https://github.com/nltk/nltk_data) repository, based on the current `index.xml` file. Each package is cited by its exact `id` and `name`, and grouped by license type as declared in the metadata.
+
+Packages with ambiguous, missing, or unclear licensing are listed in a dedicated section and explicitly noted. If a license is present but not a recognized open license, or is ambiguous, this is also noted.
+
+_Note: While this list is generated carefully and covers all packages found in the current `index.xml`, it may not be exhaustive or fully accurate—users are responsible for verifying licensing details for their own use cases, especially for commercial or redistributive use._
+
+---
+
+## MIT License
+
+- averaged_perceptron_tagger — Averaged Perceptron Tagger
+- averaged_perceptron_tagger_eng — Averaged Perceptron Tagger (JSON)
+- averaged_perceptron_tagger_ru — Averaged Perceptron Tagger (Russian)
+- averaged_perceptron_tagger_rus — Averaged Perceptron Tagger (Russian)
+- vader_lexicon — VADER Sentiment Lexicon
+
+---
+
+## Creative Commons Licenses
+
+### Creative Commons Attribution 4.0 International
+
+- opinion_lexicon — Opinion Lexicon
+- product_reviews_1 — Product Reviews (5 Products)
+- product_reviews_2 — Product Reviews (9 Products)
+- pros_cons — Pros and Cons
+- subjectivity — Subjectivity Dataset v1.0
+
+### Creative Commons Attribution 3.0 Unported License
+
+- framenet_v17 — FrameNet 1.7
+
+### Creative Commons Attribution-NonCommercial-ShareAlike 3.0 United States
+
+- universal_treebanks_v20 — Universal Treebanks Version 2.0
+
+### Creative Commons Attribution 3.0 (unspecified region)
+
+- sentiwordnet — SentiWordNet
+
+### CC0 1.0 Universal
+
+- panlex_swadesh — PanLex Swadesh Corpora
+
+### CC by SA 3.0 Licence (for data from Wiktionary) and UBY 1.0 (for data from UBY)
+
+- extended_omw — Extended Open Multilingual WordNet
+
+---
+
+## GNU Licenses
+
+### GNU General Public License
+
+- pl196x — Polish language of the XX century sixties
+
+### GNU Free Documentation License
+
+- swadesh — Swadesh Wordlists
+- gazetteers — Gazetteer Lists (note: for some files only, others may be public domain)
+
+### Gnu Lesser General Public License
+
+- nonbreaking_prefixes — Non-Breaking Prefixes (Moses Decoder)
+
+---
+
+## Public Domain
+
+- genesis — Genesis Corpus
+- gutenberg — Project Gutenberg Selections
+- inaugural — C-Span Inaugural Address Corpus
+- shakespeare — Shakespeare XML Corpus Sample
+- udhr — Universal Declaration of Human Rights Corpus
+- udhr2 — Universal Declaration of Human Rights Corpus (Unicode Version)
+- words — Word Lists
+
+---
+
+## “Distributed with Permission” / “May be used with Permission” / “Freely Redistributable”
+
+> **Warning:** These are not standard open licenses. Redistribution or modification may be restricted.
+
+- alpino — Alpino Dutch Treebank (“Distributed with permission of Gertjan van Noord”)
+- indian — Indian Language POS-Tagged Corpus (“Distributed with permission”)
+- lin_thesaurus — Lin's Dependency Thesaurus (“Distributed with permission of Dekang Lin”)
+- mac_morpho — MAC-MORPHO: Brazilian Portuguese news text with part-of-speech tags (“Distributed with permission of Nílson C. Sanderson”)
+- paradigms — Paradigm Corpus (“Distributed with the permission of the author”)
+- nombank.1.0 — NomBank Corpus 1.0 (“Distributed with permission”)
+- propbank — Proposition Bank Corpus 1.0 (“Distributed with permission”)
+- senseval — SENSEVAL 2 Corpus: Sense Tagged Text (“Distributed with permission.”)
+- verbnet — VerbNet Lexicon, Version 2.1 (“Distributed with permission of the author”)
+- verbnet3 — VerbNet Lexicon, Version 3.3 (“Distributed with permission of the author”)
+- maxent_treebank_pos_tagger — Treebank Part of Speech Tagger (Maximum entropy)
+- maxent_treebank_pos_tagger_tab — Treebank Part of Speech Tagger (Maximum entropy)
+- maxent_ne_chunker — ACE Named Entity Chunker (Maximum entropy)
+- maxent_ne_chunker_tab — ACE Named Entity Chunker (Maximum entropy)
+- pil — The Patient Information Leaflet (PIL) Corpus (“Distributed with permission”)
+- pe08 — Cross-Framework and Cross-Domain Parser Evaluation Shared Task (“Distributed with permission”)
+- kimmo — PC-KIMMO Data Files (“Distributed with permission”)
+- jeita — JEITA Public Morphologically Tagged Corpus (“Freely re-distributable under the same license as the original KNB Corpus”)
+- knbc — KNB Corpus (Annotated blog corpus) (“Freely re-distributable under the same license as the original KNB Corpus”)
+
+---
+
+## “Non-commercial Use Only” / Educational Use
+
+- brown — Brown Corpus (“May be used for non-commercial purposes.”)
+- brown_tei — Brown Corpus (TEI XML Version) (“May be used for non-commercial purposes.”)
+- framenet_v15 — FrameNet 1.5 (“May be used for non-commercial purposes.”)
+- floresta — Portuguese Treebank (“Non-commercial use only”)
+- masc_tagged — MASC Tagged Corpus (“This data may be used for the purposes of linguistic education and research only.”)
+- nps_chat — NPS Chat (“This corpus is distributed solely for non-commercial research purposes.”)
+
+---
+
+## “Please Consult LICENSE Files” (Aggregated/Mixed Licensing)
+
+> **Warning:** These packages include files from multiple sources, each with their own license. See LICENSE files inside the package.
+
+- omw — Open Multilingual Wordnet (“Please consult the LICENSE files included with the individual Wordnets. Note that all permit redistribution.”)
+- omw-1.4 — Open Multilingual Wordnet (same as above)
+
+---
+
+## Special Cases, Custom, or Unique Licenses
+
+- bcp47 — BCP-47 Language Tags (“IETF Trust and Unicode Inc.”; custom)
+- wordnet — WordNet (“Permission to use, copy, modify and distribute this software and database and its documentation for any purpose and without fee or royalty”)
+- wordnet31 — Wordnet 3.1 (same as above)
+- wordnet2021 / wordnet2022 / english_wordnet — Open English Wordnet (“This resource is derived from Princeton WordNet under the WordNet License and further developed under the Creative Commons Attribution License.”)
+- twitter_samples — Twitter Samples (“Must be used subject to Twitter Developer Agreement”)
+- switchboard — Switchboard Corpus Sample (“Permission is granted for use of this material in accordance with the Open Content License [http://opencontent.org/opl.shtml].”)
+- dependency_treebank — Dependency Parsed Treebank (“This is a 10% fragment of Penn Treebank, (C) LDC 1995.  It may only be used for non-commercial purposes and may not be redistributed.”)
+- ptb — Penn Treebank (“This is a stub for the full Penn Treebank Corpus version 3.”)
+- treebank — Penn Treebank Sample (“This is a 10% fragment of Penn Treebank, (C) LDC 1995.  It may only be used for non-commercial purposes and may not be redistributed.”)
+- conll2000 — CONLL 2000 Chunking Corpus (“Permission is granted to use and distribute this data for research purposes only provided this copyright notice is retained.”)
+- conll2002 — CONLL 2002 Named Entity Recognition Corpus (no explicit license, see website)
+- conll2007 — Dependency Treebanks from CoNLL 2007 (Catalan and Basque Subset) (copyrighted, see website)
+- ieer — NIST IE-ER DATA SAMPLE (copyrighted, see website)
+- reuters — The Reuters-21578 benchmark corpus, ApteMod version (“The copyright for the text of newswire articles ... remains with Reuters Ltd.”)
+- timit — TIMIT Corpus Sample (“Copyright 1993 Linguistic Data Consortium, and is distributed under the terms of the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 license.”)
+
+---
+
+## Unclarified, Unknown, or Ambiguous License
+
+The following packages have no `license` attribute, an empty value, a citation request instead of a license, or otherwise ambiguous status.  
+**_Treat these as unclarified unless clarified by upstream or additional documentation!_**
+
+> **Note:** Despite long-standing and ongoing community efforts—witnessed through several open issues in both the [`nltk`](https://github.com/nltk/nltk/issues) and [`nltk_data`](https://github.com/nltk/nltk_data/issues) GitHub repositories—no clarification has yet been possible for these packages. The most notable case is the Punkt Tokenizer Models, but many others remain unresolved. The project continues to seek clarification, but users should exercise particular caution.
+
+- abc — Australian Broadcasting Commission 2006
+- basque_grammars — Grammars for Basque
+- biocreative_ppi — BioCreAtIvE (Critical Assessment of Information Extraction Systems in Biology)
+- bllip_wsj_no_aux — BLLIP Parser: WSJ Model
+- book_grammars — Grammars from NLTK Book
+- cess_cat — CESS-CAT Treebank (“If you use these corpora for research, please cite thusly: CESS-Cat project ...”)
+- cess_esp — CESS-ESP Treebank (“If you use these corpora for research, please cite thusly: CESS-Cat project ...”)
+- chat80 — Chat-80 Data Files (“This program may be used, copied, altered or included in other programs ... for research, educational, and non-commercial purposes only.”)
+- city_database — City Database
+- cmudict — The Carnegie Mellon Pronouncing Dictionary (0.6)
+- comparative_sentences — Comparative Sentence Dataset (license present, but ambiguous version)
+- comtrans — ComTrans Corpus Sample
+- dolch — Dolch Word List
+- europarl_raw — Sample European Parliament Proceedings Parallel Corpus
+- framenet_v15 — FrameNet 1.5 (license is “May be used for non-commercial purposes.”)
+- gazetteers — Gazetteer Lists (license is mixed per-file, see note above)
+- large_grammars — Large context-free and feature-based grammars for parser comparison
+- machado — Machado de Assis -- Obra Completa (“Public Domain”, but recommend verifying at source)
+- moses_sample — Moses Sample Models
+- mwa_ppdb — The monolingual word aligner (Sultan et al. 2015) subset of the Paraphrase Database.
+- names — Names Corpus, Version 1.3 (1994-03-29)
+- nonbreaking_prefixes — Non-Breaking Prefixes (Moses Decoder) (empty string in license field)
+- punkt — Punkt Tokenizer Models (**no license attribute**)
+- punkt_tab — Punkt Tokenizer Models (**no license attribute**)
+- porter_test — Porter Stemmer Test Files
+- ppattach — Prepositional Phrase Attachment Corpus
+- problem_reports — Problem Report Corpus
+- qc — Experimental Data for Question Classification
+- rslp — RSLP Stemmer (Removedor de Sufixos da Lingua Portuguesa)
+- rte — PASCAL RTE Challenges 1, 2, and 3
+- sample_grammars — Sample Grammars
+- semcor — SemCor 3.0
+- sentence_polarity — Sentence Polarity Dataset v1.0 (license present, but ambiguous version)
+- smultron — SMULTRON Corpus Sample
+- snowball_data — Snowball Data
+- spanish_grammars — Grammars for Spanish
+- state_union — C-Span State of the Union Address Corpus
+- stopwords — Stopwords Corpus
+- tagsets — Help on Tagsets
+- tagsets_json — Help on Tagsets (JSON)
+- toolbox — Toolbox Sample Files
+- unicode_samples — Unicode Samples
+- webtext — Web Text Corpus
+- wmt15_eval — Evaluation data from WMT15
+- word2vec_sample — Word2Vec Sample
+- wordnet_ic — WordNet-InfoContent
+- ycoe — York-Toronto-Helsinki Parsed Corpus of Old English Prose
+
+---
+
+## Packages with Citation Requests Instead of Licenses
+
+These packages specifically request citation for use, but do not provide a license:
+
+- cess_cat — CESS-CAT Treebank
+- cess_esp — CESS-ESP Treebank
+
+---
+
+## Packages Citing Source Website or “See Website” for Terms
+
+- conll2002 — CONLL 2002 Named Entity Recognition Corpus
+- conll2007 — Dependency Treebanks from CoNLL 2007 (Catalan and Basque Subset)
+- ieer — NIST IE-ER DATA SAMPLE
+- reuters — The Reuters-21578 benchmark corpus, ApteMod version
+
+---
+
+## Notes
+
+- If a package is not explicitly listed under a license, check the “Unclarified, Unknown, or Ambiguous License” section.
+- This list was generated by parsing the `index.xml` file as of the time of writing, but may not reflect future changes.
+- “Distributed with permission” and similar phrases are _not_ open licenses.
+- Always consult the upstream data source or the NLTK maintainers if your use case is commercial, redistribution, or otherwise sensitive.
+- If you notice omissions or errors, please open an issue or pull request.

--- a/DATASET-LICENSES.md
+++ b/DATASET-LICENSES.md
@@ -1,10 +1,11 @@
-# Dataset Licenses
+# DATASET-LICENSES.md
 
-This document provides a grouped summary of licenses for data packages present in the [`nltk_data`](https://github.com/nltk/nltk_data) repository, based on the current `index.xml` file. Each package is cited by its exact `id` and `name`, and grouped by license type as declared in the metadata.
+This document provides a grouped summary of licenses for all data packages present in the [`nltk_data`](https://github.com/nltk/nltk_data) repository, based on the current `index.xml` file. Each package is listed by its exact `id` and `name`, and grouped by license type as declared in the metadata.
 
-Packages with ambiguous, missing, or unclear licensing are listed in a dedicated section and explicitly noted. If a license is present but not a recognized open license, or is ambiguous, this is also noted.
-
-_Note: While this list is generated carefully and covers all packages found in the current `index.xml`, it may not be exhaustive or fully accurate—users are responsible for verifying licensing details for their own use cases, especially for commercial or redistributive use._
+> **Disclaimer:**  
+> This information is provided as a convenience to users and is not legal advice.  
+> **You must verify the license for each dataset with the original source if your use case is sensitive (especially for commercial or redistributive use).**  
+> Licenses or terms can change over time; this file may become outdated if not maintained.
 
 ---
 
@@ -44,7 +45,7 @@ _Note: While this list is generated carefully and covers all packages found in t
 
 - panlex_swadesh — PanLex Swadesh Corpora
 
-### CC by SA 3.0 Licence (for data from Wiktionary) and UBY 1.0 (for data from UBY)
+### CC By SA 3.0 (Wiktionary) & UBY 1.0 (UBY)
 
 - extended_omw — Extended Open Multilingual WordNet
 
@@ -59,9 +60,9 @@ _Note: While this list is generated carefully and covers all packages found in t
 ### GNU Free Documentation License
 
 - swadesh — Swadesh Wordlists
-- gazetteers — Gazetteer Lists (note: for some files only, others may be public domain)
+- gazetteers — Gazetteer Lists (note: for some files only; others may be public domain)
 
-### Gnu Lesser General Public License
+### GNU Lesser General Public License
 
 - nonbreaking_prefixes — Non-Breaking Prefixes (Moses Decoder)
 
@@ -81,101 +82,111 @@ _Note: While this list is generated carefully and covers all packages found in t
 
 ## “Distributed with Permission” / “May be used with Permission” / “Freely Redistributable”
 
-> **Warning:** These are not standard open licenses. Redistribution or modification may be restricted.
+> **Warning:**  
+> These are not standard open licenses. Terms may prohibit redistribution, modification, or commercial use.  
+> **You must consult the upstream source for the actual terms and whether permission applies to your use case.**
 
-- alpino — Alpino Dutch Treebank (“Distributed with permission of Gertjan van Noord”)
-- indian — Indian Language POS-Tagged Corpus (“Distributed with permission”)
-- lin_thesaurus — Lin's Dependency Thesaurus (“Distributed with permission of Dekang Lin”)
-- mac_morpho — MAC-MORPHO: Brazilian Portuguese news text with part-of-speech tags (“Distributed with permission of Nílson C. Sanderson”)
-- paradigms — Paradigm Corpus (“Distributed with the permission of the author”)
-- nombank.1.0 — NomBank Corpus 1.0 (“Distributed with permission”)
-- propbank — Proposition Bank Corpus 1.0 (“Distributed with permission”)
-- senseval — SENSEVAL 2 Corpus: Sense Tagged Text (“Distributed with permission.”)
-- verbnet — VerbNet Lexicon, Version 2.1 (“Distributed with permission of the author”)
-- verbnet3 — VerbNet Lexicon, Version 3.3 (“Distributed with permission of the author”)
+- alpino — Alpino Dutch Treebank
+- indian — Indian Language POS-Tagged Corpus
+- lin_thesaurus — Lin's Dependency Thesaurus
+- mac_morpho — MAC-MORPHO: Brazilian Portuguese news text with part-of-speech tags
+- paradigms — Paradigm Corpus
+- nombank.1.0 — NomBank Corpus 1.0
+- propbank — Proposition Bank Corpus 1.0
+- senseval — SENSEVAL 2 Corpus: Sense Tagged Text
+- verbnet — VerbNet Lexicon, Version 2.1
+- verbnet3 — VerbNet Lexicon, Version 3.3
 - maxent_treebank_pos_tagger — Treebank Part of Speech Tagger (Maximum entropy)
 - maxent_treebank_pos_tagger_tab — Treebank Part of Speech Tagger (Maximum entropy)
 - maxent_ne_chunker — ACE Named Entity Chunker (Maximum entropy)
 - maxent_ne_chunker_tab — ACE Named Entity Chunker (Maximum entropy)
-- pil — The Patient Information Leaflet (PIL) Corpus (“Distributed with permission”)
-- pe08 — Cross-Framework and Cross-Domain Parser Evaluation Shared Task (“Distributed with permission”)
-- kimmo — PC-KIMMO Data Files (“Distributed with permission”)
-- jeita — JEITA Public Morphologically Tagged Corpus (“Freely re-distributable under the same license as the original KNB Corpus”)
-- knbc — KNB Corpus (Annotated blog corpus) (“Freely re-distributable under the same license as the original KNB Corpus”)
+- pil — The Patient Information Leaflet (PIL) Corpus
+- pe08 — Cross-Framework and Cross-Domain Parser Evaluation Shared Task
+- kimmo — PC-KIMMO Data Files
+- jeita — JEITA Public Morphologically Tagged Corpus
+- knbc — KNB Corpus (Annotated blog corpus)
 
 ---
 
 ## “Non-commercial Use Only” / Educational Use
 
-- brown — Brown Corpus (“May be used for non-commercial purposes.”)
-- brown_tei — Brown Corpus (TEI XML Version) (“May be used for non-commercial purposes.”)
-- framenet_v15 — FrameNet 1.5 (“May be used for non-commercial purposes.”)
-- floresta — Portuguese Treebank (“Non-commercial use only”)
-- masc_tagged — MASC Tagged Corpus (“This data may be used for the purposes of linguistic education and research only.”)
-- nps_chat — NPS Chat (“This corpus is distributed solely for non-commercial research purposes.”)
+- brown — Brown Corpus
+- brown_tei — Brown Corpus (TEI XML Version)
+- framenet_v15 — FrameNet 1.5
+- floresta — Portuguese Treebank
+- masc_tagged — MASC Tagged Corpus
+- nps_chat — NPS Chat
 
 ---
 
-## “Please Consult LICENSE Files” (Aggregated/Mixed Licensing)
+## “See LICENSE Files” (Aggregated/Mixed Licensing)
 
-> **Warning:** These packages include files from multiple sources, each with their own license. See LICENSE files inside the package.
+> **Warning:**  
+> These packages include files from multiple sources, each with their own license. See LICENSE files inside the package and verify terms for your use case.
 
-- omw — Open Multilingual Wordnet (“Please consult the LICENSE files included with the individual Wordnets. Note that all permit redistribution.”)
-- omw-1.4 — Open Multilingual Wordnet (same as above)
+- omw — Open Multilingual Wordnet
+- omw-1.4 — Open Multilingual Wordnet
 
 ---
 
 ## Special Cases, Custom, or Unique Licenses
 
-- bcp47 — BCP-47 Language Tags (“IETF Trust and Unicode Inc.”; custom)
-- wordnet — WordNet (“Permission to use, copy, modify and distribute this software and database and its documentation for any purpose and without fee or royalty”)
+- bcp47 — BCP-47 Language Tags ("IETF Trust and Unicode Inc."; custom)
+- wordnet — WordNet ("Permission to use, copy, modify and distribute this software and database and its documentation for any purpose and without fee or royalty")
 - wordnet31 — Wordnet 3.1 (same as above)
-- wordnet2021 / wordnet2022 / english_wordnet — Open English Wordnet (“This resource is derived from Princeton WordNet under the WordNet License and further developed under the Creative Commons Attribution License.”)
-- twitter_samples — Twitter Samples (“Must be used subject to Twitter Developer Agreement”)
-- switchboard — Switchboard Corpus Sample (“Permission is granted for use of this material in accordance with the Open Content License [http://opencontent.org/opl.shtml].”)
-- dependency_treebank — Dependency Parsed Treebank (“This is a 10% fragment of Penn Treebank, (C) LDC 1995.  It may only be used for non-commercial purposes and may not be redistributed.”)
-- ptb — Penn Treebank (“This is a stub for the full Penn Treebank Corpus version 3.”)
-- treebank — Penn Treebank Sample (“This is a 10% fragment of Penn Treebank, (C) LDC 1995.  It may only be used for non-commercial purposes and may not be redistributed.”)
-- conll2000 — CONLL 2000 Chunking Corpus (“Permission is granted to use and distribute this data for research purposes only provided this copyright notice is retained.”)
-- conll2002 — CONLL 2002 Named Entity Recognition Corpus (no explicit license, see website)
-- conll2007 — Dependency Treebanks from CoNLL 2007 (Catalan and Basque Subset) (copyrighted, see website)
-- ieer — NIST IE-ER DATA SAMPLE (copyrighted, see website)
-- reuters — The Reuters-21578 benchmark corpus, ApteMod version (“The copyright for the text of newswire articles ... remains with Reuters Ltd.”)
-- timit — TIMIT Corpus Sample (“Copyright 1993 Linguistic Data Consortium, and is distributed under the terms of the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 license.”)
+- wordnet2021 / wordnet2022 / english_wordnet — Open English Wordnet (combines WordNet License and Creative Commons Attribution)
+- twitter_samples — Twitter Samples ("Must be used subject to Twitter Developer Agreement")
+- switchboard — Switchboard Corpus Sample ("Permission is granted for use of this material in accordance with the Open Content License")
+- dependency_treebank — Dependency Parsed Treebank (fragment of Penn Treebank; non-commercial, no redistribution)
+- ptb — Penn Treebank (stub for full corpus)
+- treebank — Penn Treebank Sample (fragment; non-commercial, no redistribution)
+- conll2000 — CONLL 2000 Chunking Corpus (research use only)
+- conll2002 — CONLL 2002 Named Entity Recognition Corpus (see website)
+- conll2007 — Dependency Treebanks from CoNLL 2007 (Catalan and Basque Subset, see website)
+- ieer — NIST IE-ER DATA SAMPLE (see website)
+- reuters — Reuters-21578 benchmark corpus, ApteMod version (Reuters Ltd. copyright)
+- timit — TIMIT Corpus Sample (Creative Commons Attribution-NonCommercial-ShareAlike 3.0)
 
 ---
 
-## Unclarified, Unknown, or Ambiguous License
+## Unclarified, Unknown, Ambiguous, or Citation-Only
 
-The following packages have no `license` attribute, an empty value, a citation request instead of a license, or otherwise ambiguous status.  
-**_Treat these as unclarified unless clarified by upstream or additional documentation!_**
+The following packages have:  
+- No `license` attribute  
+- An empty or ambiguous value  
+- A citation request instead of a license  
+- Or otherwise ambiguous status
 
-> **Note:** Despite long-standing and ongoing community efforts—witnessed through several open issues in both the [`nltk`](https://github.com/nltk/nltk/issues) and [`nltk_data`](https://github.com/nltk/nltk_data/issues) GitHub repositories—no clarification has yet been possible for these packages. The most notable case is the Punkt Tokenizer Models, but many others remain unresolved. The project continues to seek clarification, but users should exercise particular caution.
+> **Warning:**  
+> These packages lack open, standard, or clearly documented licenses.  
+> Citation requests do **not** constitute a license.  
+> Despite long-standing and ongoing efforts (see [nltk_data issue #241](https://github.com/nltk/nltk_data/issues/241) and related discussions), clarification has not been possible for these cases.  
+> **If you need to use any of these for commercial or redistributive purposes, consult a qualified legal professional.**
 
 - abc — Australian Broadcasting Commission 2006
 - basque_grammars — Grammars for Basque
 - biocreative_ppi — BioCreAtIvE (Critical Assessment of Information Extraction Systems in Biology)
 - bllip_wsj_no_aux — BLLIP Parser: WSJ Model
 - book_grammars — Grammars from NLTK Book
-- cess_cat — CESS-CAT Treebank (“If you use these corpora for research, please cite thusly: CESS-Cat project ...”)
-- cess_esp — CESS-ESP Treebank (“If you use these corpora for research, please cite thusly: CESS-Cat project ...”)
-- chat80 — Chat-80 Data Files (“This program may be used, copied, altered or included in other programs ... for research, educational, and non-commercial purposes only.”)
+- cess_cat — CESS-CAT Treebank (citation requested, not a license)
+- cess_esp — CESS-ESP Treebank (citation requested, not a license)
+- chat80 — Chat-80 Data Files
 - city_database — City Database
 - cmudict — The Carnegie Mellon Pronouncing Dictionary (0.6)
-- comparative_sentences — Comparative Sentence Dataset (license present, but ambiguous version)
+- comparative_sentences — Comparative Sentence Dataset (ambiguous license)
 - comtrans — ComTrans Corpus Sample
 - dolch — Dolch Word List
 - europarl_raw — Sample European Parliament Proceedings Parallel Corpus
-- framenet_v15 — FrameNet 1.5 (license is “May be used for non-commercial purposes.”)
-- gazetteers — Gazetteer Lists (license is mixed per-file, see note above)
-- large_grammars — Large context-free and feature-based grammars for parser comparison
-- machado — Machado de Assis -- Obra Completa (“Public Domain”, but recommend verifying at source)
+- framenet_v15 — FrameNet 1.5 (non-commercial use only)
+- gazetteers — Gazetteer Lists (mixed per-file)
+- large_grammars — Large context-free and feature-based grammars
+- machado — Machado de Assis -- Obra Completa ("Public Domain", verify at source)
 - moses_sample — Moses Sample Models
-- mwa_ppdb — The monolingual word aligner (Sultan et al. 2015) subset of the Paraphrase Database.
+- mwa_ppdb — Monolingual word aligner (subset of Paraphrase Database)
 - names — Names Corpus, Version 1.3 (1994-03-29)
-- nonbreaking_prefixes — Non-Breaking Prefixes (Moses Decoder) (empty string in license field)
-- punkt — Punkt Tokenizer Models (**no license attribute**)
-- punkt_tab — Punkt Tokenizer Models (**no license attribute**)
+- nonbreaking_prefixes — Non-Breaking Prefixes (empty license field)
+- punkt — Punkt Tokenizer Models (no license attribute)
+- punkt_tab — Punkt Tokenizer Models (no license attribute)
 - porter_test — Porter Stemmer Test Files
 - ppattach — Prepositional Phrase Attachment Corpus
 - problem_reports — Problem Report Corpus
@@ -184,7 +195,7 @@ The following packages have no `license` attribute, an empty value, a citation r
 - rte — PASCAL RTE Challenges 1, 2, and 3
 - sample_grammars — Sample Grammars
 - semcor — SemCor 3.0
-- sentence_polarity — Sentence Polarity Dataset v1.0 (license present, but ambiguous version)
+- sentence_polarity — Sentence Polarity Dataset v1.0 (ambiguous license)
 - smultron — SMULTRON Corpus Sample
 - snowball_data — Snowball Data
 - spanish_grammars — Grammars for Spanish
@@ -204,7 +215,8 @@ The following packages have no `license` attribute, an empty value, a citation r
 
 ## Packages with Citation Requests Instead of Licenses
 
-These packages specifically request citation for use, but do not provide a license:
+> **Note:**  
+> These packages specifically request citation for use, but do not provide a license. Citation requests are not a license.
 
 - cess_cat — CESS-CAT Treebank
 - cess_esp — CESS-ESP Treebank
@@ -213,6 +225,9 @@ These packages specifically request citation for use, but do not provide a licen
 
 ## Packages Citing Source Website or “See Website” for Terms
 
+> **Note:**  
+> These packages refer users to an external website for their licensing terms.
+
 - conll2002 — CONLL 2002 Named Entity Recognition Corpus
 - conll2007 — Dependency Treebanks from CoNLL 2007 (Catalan and Basque Subset)
 - ieer — NIST IE-ER DATA SAMPLE
@@ -220,10 +235,9 @@ These packages specifically request citation for use, but do not provide a licen
 
 ---
 
-## Notes
+## Maintenance
 
-- If a package is not explicitly listed under a license, check the “Unclarified, Unknown, or Ambiguous License” section.
-- This list was generated by parsing the `index.xml` file as of the time of writing, but may not reflect future changes.
-- “Distributed with permission” and similar phrases are _not_ open licenses.
-- Always consult the upstream data source or the NLTK maintainers if your use case is commercial, redistribution, or otherwise sensitive.
-- If you notice omissions or errors, please open an issue or pull request.
+**If you add, update, or remove any data packages, update this file accordingly to ensure continued transparency and compliance.**  
+If you find omissions, errors, or outdated information, please open an issue or pull request.
+
+---

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-OVERVIEW.md
+++ b/LICENSE-OVERVIEW.md
@@ -1,0 +1,39 @@
+# LICENSE-OVERVIEW.md
+
+## Overview
+
+This repository, [`nltk_data`](https://github.com/nltk/nltk_data), is governed as a whole by the [Apache License 2.0](LICENSE). However, **the individual data packages included in this repository are subject to a wide variety of licenses**, which are not always the same as the repository-wide license. Many datasets are covered by permissive open licenses (MIT, Creative Commons, etc.), some are public domain, and others are distributed with custom terms or with explicit restrictions (e.g., non-commercial use only, distributed with permission, or educational use only).
+
+**It is essential to consult the specific license for each dataset before use, particularly for commercial or redistributive purposes.**  
+A comprehensive, grouped list of licenses for each data package is provided in [DATASET-LICENSES.md](DATASET-LICENSES.md).
+
+## Special Notes
+
+- **Unclarified and Ambiguous Licenses:**  
+  Several data packages have ambiguous, missing, or unclarified licenses (notably, the Punkt Tokenizer Models). Despite long-standing community efforts documented in both the [`nltk`](https://github.com/nltk/nltk/issues) and [`nltk_data`](https://github.com/nltk/nltk_data/issues) repositories, clarification has not always been possible. These packages are grouped and highlighted in [DATASET-LICENSES.md](DATASET-LICENSES.md).  
+  If you have legal questions or concerns about using any package with an unclear or ambiguous license, you should consult a qualified legal professional. Open-source developers and maintainers are not able to provide legal advice.
+
+- **Repository License:**  
+  All code and repository-level content is provided under the Apache License 2.0 unless otherwise noted.
+
+- **Data Package Licenses:**  
+  Each data package may have its own license, as detailed in [DATASET-LICENSES.md](DATASET-LICENSES.md). These may include:
+  - Open source licenses (MIT, various Creative Commons, GPL, etc.)
+  - Public domain
+  - Custom or restrictive terms ("distributed with permission", "non-commercial use only", "see website", etc.)
+  - Citation requests in lieu of a license
+  - Explicitly unclarified or missing terms
+
+## Your Responsibilities
+
+- **Check the Dataset License:**  
+  Before using, modifying, or redistributing any data package, **read the relevant license entry in [DATASET-LICENSES.md](DATASET-LICENSES.md)** and consult upstream sources if your use case is sensitive.
+
+- **When in Doubt:**  
+  If the license is missing, ambiguous, or does not suit your intended use, do not assume that commercial or public redistribution is allowed. Seek advice from a qualified lawyer or legal professional; open-source project maintainers cannot provide legal guidance.
+
+## Apache License 2.0
+
+See the [LICENSE](LICENSE) file for the full text of the repository-wide license.
+
+---

--- a/LICENSE-OVERVIEW.md
+++ b/LICENSE-OVERVIEW.md
@@ -2,38 +2,49 @@
 
 ## Overview
 
-This repository, [`nltk_data`](https://github.com/nltk/nltk_data), is governed as a whole by the [Apache License 2.0](LICENSE). However, **the individual data packages included in this repository are subject to a wide variety of licenses**, which are not always the same as the repository-wide license. Many datasets are covered by permissive open licenses (MIT, Creative Commons, etc.), some are public domain, and others are distributed with custom terms or with explicit restrictions (e.g., non-commercial use only, distributed with permission, or educational use only).
+This repository (`nltk_data`) is governed as a whole by the [Apache License 2.0](LICENSE). However, **the individual data packages included in this repository are each subject to their own licenses**, which may differ substantially from the repository-wide license. Packages may be covered by open licenses (MIT, Creative Commons, etc.), public domain dedication, custom or restrictive terms (such as "non-commercial use only" or "distributed with permission"), or may lack explicit license terms entirely.
 
-**It is essential to consult the specific license for each dataset before use, particularly for commercial or redistributive purposes.**  
-A comprehensive, grouped list of licenses for each data package is provided in [DATASET-LICENSES.md](DATASET-LICENSES.md).
+> **Important:**  
+> You must consult the specific license for each dataset before use, especially for commercial or redistributive purposes.  
+> See [DATASET-LICENSES.md](DATASET-LICENSES.md) for a grouped summary of package licenses.
+
+Maintainers are not legal professionals and cannot answer legal questions or provide legal advice.  
+If you have any doubts or require legal interpretation, **consult a qualified legal professional**.
 
 ## Special Notes
 
-- **Unclarified and Ambiguous Licenses:**  
-  Several data packages have ambiguous, missing, or unclarified licenses (notably, the Punkt Tokenizer Models). Despite long-standing community efforts documented in both the [`nltk`](https://github.com/nltk/nltk/issues) and [`nltk_data`](https://github.com/nltk/nltk_data/issues) repositories, clarification has not always been possible. These packages are grouped and highlighted in [DATASET-LICENSES.md](DATASET-LICENSES.md).  
-  If you have legal questions or concerns about using any package with an unclear or ambiguous license, you should consult a qualified legal professional. Open-source developers and maintainers are not able to provide legal advice.
+- **Unclarified, Ambiguous, or Missing Licenses**  
+  Some data packages have ambiguous, missing, or unclarified licenses (most notably the Punkt Tokenizer Models). Despite long-standing community efforts (see [nltk_data issue #241](https://github.com/nltk/nltk_data/issues/241) and related issues), clarification has not always been possible.  
+  These packages are grouped and flagged in [DATASET-LICENSES.md](DATASET-LICENSES.md) with explicit warnings.  
+  If you have legal questions or concerns about using any package with an unclear or ambiguous license, consult a qualified lawyer. Do not rely on assumptions, community answers, or advice from maintainers.
 
-- **Repository License:**  
-  All code and repository-level content is provided under the Apache License 2.0 unless otherwise noted.
+- **This Documentation is Not Legal Advice**  
+  The information in these files is provided for convenience and transparency, and does not constitute legal advice.  
+  You are responsible for ensuring your own legal compliance when using, modifying, or redistributing any content from this repository.
 
-- **Data Package Licenses:**  
-  Each data package may have its own license, as detailed in [DATASET-LICENSES.md](DATASET-LICENSES.md). These may include:
-  - Open source licenses (MIT, various Creative Commons, GPL, etc.)
-  - Public domain
-  - Custom or restrictive terms ("distributed with permission", "non-commercial use only", "see website", etc.)
-  - Citation requests in lieu of a license
-  - Explicitly unclarified or missing terms
+## Data Package Licenses
+
+Each data package may have its own license, as detailed in [DATASET-LICENSES.md](DATASET-LICENSES.md). These may include (but are not limited to):
+- Open source licenses (MIT, various Creative Commons, GPL, etc.)
+- Public domain dedication
+- Custom or restrictive terms ("distributed with permission", "non-commercial use only", "see website", etc.)
+- Citation requests (note: a citation request does not constitute a license)
+- No license or ambiguous terms
+
+If a license is unclear, missing, or does not suit your intended use, **do not assume that commercial or public redistribution is allowed**.
 
 ## Your Responsibilities
 
 - **Check the Dataset License:**  
-  Before using, modifying, or redistributing any data package, **read the relevant license entry in [DATASET-LICENSES.md](DATASET-LICENSES.md)** and consult upstream sources if your use case is sensitive.
+  Before using, modifying, or redistributing any data package, check the relevant license entry in [DATASET-LICENSES.md](DATASET-LICENSES.md) and, if necessary, consult the original data source for updated terms.
 
 - **When in Doubt:**  
-  If the license is missing, ambiguous, or does not suit your intended use, do not assume that commercial or public redistribution is allowed. Seek advice from a qualified lawyer or legal professional; open-source project maintainers cannot provide legal guidance.
+  If the license is missing, ambiguous, or unclear, or if you are unsure about your intended use, seek advice from a qualified legal professional.
+
+## Keeping This Documentation Up to Date
+
+If you add, update, or remove datasets, please also update [DATASET-LICENSES.md](DATASET-LICENSES.md) and this overview file to ensure continued transparency for all users.
 
 ## Apache License 2.0
 
 See the [LICENSE](LICENSE) file for the full text of the repository-wide license.
-
----

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Data Distribution for NLTK
+
+This repository contains data packages (corpora, models, tokenizers, etc.) for use with [NLTK](https://www.nltk.org/).
+
+## Installation
+
+To install data using the NLTK downloader, run:
+
+```python
+import nltk
+nltk.download()
+```
+
+For detailed instructions, please see the [NLTK website](https://www.nltk.org/).
+
+---
+
+## Recent Enhancements
+
+### Licensing Transparency ([PR #242](https://github.com/nltk/nltk_data/pull/242))
+- Added a top-level `LICENSE` (Apache License 2.0) for the repository.
+- Added `LICENSE-OVERVIEW.md` summarizing the licensing structure, with emphasis on the diversity of dataset licenses and the importance of reviewing individual terms.
+- Added `DATASET-LICENSES.md` — a comprehensive, grouped list of all data packages and their licenses, highlighting any ambiguous or unclarified licensing.
+- These changes improve transparency, support responsible use, and aid compliance for all users.
+
+### Contribution Guidelines
+- Introduced a detailed `CONTRIBUTING.md` with step-by-step instructions for adding a new data package using Git and GitHub.
+- Please see `CONTRIBUTING.md` for instructions on adding datasets and making other contributions.
+- Contributors are encouraged to clarify dataset licenses and to consult the new licensing overview and dataset license table.
+
+---
+
+*For instructions on adding new data packages, please see [CONTRIBUTING.md](CONTRIBUTING.md). For licensing details, see [LICENSE-OVERVIEW.md](LICENSE-OVERVIEW.md) and [DATASET-LICENSES.md](DATASET-LICENSES.md).*

--- a/README.txt
+++ b/README.txt
@@ -1,7 +1,0 @@
-Data Distribution for NLTK
-
-Install using NLTK downloader: nltk.download()
-
-For instructions please see http://www.nltk.org/
-
-


### PR DESCRIPTION
This PR resolves #241 by adding three key files to clarify the licensing structure of the `nltk_data` repository:

- **LICENSE** — The full text of the Apache License 2.0, which applies to the repository as a whole.
- **LICENSE-OVERVIEW.md** — A concise, human-readable summary of the repository’s licensing, emphasizing the diversity of data package licenses and the need for users to review individual dataset terms.
- **DATASET-LICENSES.md** — A comprehensive, grouped list of all individual data packages and their licenses, including explicit notes and warnings regarding packages with ambiguous or unclarified licensing.

These additions are intended to increase transparency, support responsible use, and improve compliance for all users of `nltk_data`.

This intends to close #241.