### PR TITLE
Add index.xml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore index.xml so it is not committed by contributors
+index.xml


### PR DESCRIPTION
This pull request adds index.xml to .gitignore.

Adding index.xml to .gitignore is a safe and effective way to solve the user-side of the issue described in #232. By ignoring this file, contributors are prevented from accidentally uploading or modifying index.xml in their pull requests, which helps avoid merge conflicts and the risk of overwriting a newer version.

This change addresses the immediate problem of unwanted index.xml uploads, while still allowing for future improvements. Server-side automation can be added later to ensure index.xml is always kept up-to-date automatically.

This simple step helps maintain repository consistency and reduces manual errors from contributors.