### PR TITLE
 Automate index.xml rebuild via GitHub Actions after package updates

### DIFF
--- a/.github/workflows/pkg_index.yml
+++ b/.github/workflows/pkg_index.yml
@@ -1,0 +1,32 @@
+name: Build and commit index.xml on package update
+
+on:
+  push:
+    branches:
+      - gh-pages
+    paths:
+      - 'packages/**'
+
+jobs:
+  build-index:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install make
+        run: sudo apt-get update && sudo apt-get install -y make
+
+      - name: Build index.xml
+        run: make pkg_index
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit and push index.xml
+        run: |
+          git add index.xml
+          git commit -m "Auto-build index.xml after package update" || echo "No changes to commit"
+          git push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,8 @@ You only need to update [`LICENSE-OVERVIEW.md`](LICENSE-OVERVIEW.md) if you are 
 
 ### 4. Update Index Files
 
-- If required, update any index or metadata files so that the new dataset is discoverable by NLTK’s downloader. Follow the format of the existing files.
+- You do **not** need to manually update `index.xml`. This file is now rebuilt automatically by a GitHub Actions workflow after your changes are merged.
+- Any local changes you make to `index.xml` will be ignored and overwritten by the workflow.
 - Provide a short README or metadata file describing the package, its origin, and its license.
 
 ### 5. Commit and Push Your Changes

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ For detailed instructions, please see the [NLTK website](https://www.nltk.org/).
 
 ## Recent Enhancements
 
+> **Note:** You do not need to update `index.xml` when adding or modifying packages. It is automatically rebuilt after changes are merged.
+
 ### Licensing Transparency ([PR #242](https://github.com/nltk/nltk_data/pull/242))
 - Added a top-level `LICENSE` (Apache License 2.0) for the repository.
 - Added `LICENSE-OVERVIEW.md` summarizing the licensing structure, with emphasis on the diversity of dataset licenses and the importance of reviewing individual terms.


### PR DESCRIPTION
This PR addresses and resolves #232 by introducing a GitHub Actions workflow that automatically rebuilds and commits index.xml whenever packages are added or changed in the repository. With this automation, contributors no longer need to manually update index.xml—any local changes to this file are now ignored and overwritten by the workflow after relevant changes are merged.

This approach eliminates the risk of accidental clobbering or merge conflicts involving index.xml, streamlining the data package contribution process. The documentation (README and CONTRIBUTING) has also been updated to clarify that index.xml is now fully managed by automation.

This PR supersedes and replaces #243, providing a more robust and automated solution.