### PR TITLE
Trigger automatic index rebuild

### DIFF
--- a/packages/corpora/mock_corpus.xml
+++ b/packages/corpora/mock_corpus.xml
@@ -2,6 +2,6 @@
     id="mock_corpus"
     name="Mock Corpus"
     description="This is a mock corpus for testing the index.xml automation workflow. It can be safely added and removed."
-    unzip="1"
+    unzip="0"
     license="Public Domain"
     />


### PR DESCRIPTION
The present PR is intended to trigger an automatic rebuild of the package index, by a small change in  _nltk_data/corpora/mock_package.xml_.

Sometimes there is a need to rebuild the package index, although no package has changed. For ex. when the forthcoming [PR #3411 on NLTK](https://github.com/nltk/nltk/pull/3411) is ready, we will need both an md5 and a sha checksum for each package in the index, to support both old users who expect a md5, and future users who need a SHA.

Since PR #245, the index is rebuilt automatically when there is a git push. But this automation is only known to have worked once, and it would be practical to test it again. 

So the intention is to merge this PR after the forthcoming [PR #3411 on NLTK](https://github.com/nltk/nltk/pull/3411). If all goes well the CI action would use an updated _build_index_ function in _nltk.downloader.py_, that outputs both md5 and sha checksums for each package in nltk_data's _index.xml_.