### PR TITLE
Install NLTK from the develop branch

### DIFF
--- a/.github/workflows/pkg_index.yml
+++ b/.github/workflows/pkg_index.yml
@@ -19,8 +19,8 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Install dependencies
-        run: pip install nltk
+      - name: Install NLTK from develop branch
+        run: pip install git+https://github.com/nltk/nltk.git@develop
 
       - name: Install make
         run: sudo apt-get update && sudo apt-get install -y make


### PR DESCRIPTION
Merging PR #248 rebult the index, but it did not include the new sha256 checksums from NLTK's PR #3411. The reason is that nltk_data's CI uses a standard nltk release, while we need it to use the git "develop" branch on this occasion. 
 