### PR TITLE
Mock update, to trigger index rebuild

### DIFF
--- a/packages/corpora/mock_corpus.xml
+++ b/packages/corpora/mock_corpus.xml
@@ -2,6 +2,6 @@
     id="mock_corpus"
     name="Mock Corpus"
     description="This is a mock corpus for testing the index.xml automation workflow. It can be safely added and removed."
-    unzip="0"
+    unzip="1"
     license="Public Domain"
     />


### PR DESCRIPTION
The present PR is intended to trigger an automatic rebuild of the package index, by a small change in nltk_data/corpora/mock_package.xml.

This should add the new SHA-256 checksums to the index.xml, which were introduced by the _nltk_ PR https://github.com/nltk/nltk/pull/3411. If all goes well, the CI action will apply the updated _build_index_ function from nltk.downloader.py, that outputs both _md5_ and _sha_ checksums for each package in nltk_data's index.xml.